### PR TITLE
Giant´s attack bug fix

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -50,7 +50,7 @@ for(int y=0; y<50; y++){
     else if(value>80&&value<100) color=sf::Color(204,174,98);
     else if(value>=100) color=sf::Color(100,20,20);
     gameMap[y*50+x].color=color;
-    gameMap[y*50+x].position={x,y};
+    gameMap[y*50+x].position = {(float)x,(float)y}; // Float cast added to compile in Visual Studio
 }
 actualMap=sf::VertexArray(sf::Quads,10000);
 for(int x=0; x<50; x++)

--- a/Projectile/Rock.cpp
+++ b/Projectile/Rock.cpp
@@ -7,6 +7,11 @@ rotate(atan2(velY,velX)*180/3.14);
 }
 void Rock::onImpact(sf::Time elapsed, Character& target, std::vector<ParticleSystem> &particleSystem){
     target.removeHealth(damage, EARTH, particleSystem);
-    target.velocity+=velocity*15.f;
+
+    if(velocity.x != 0 && velocity.y != 0)
+        target.velocity += velocity*15.f;
+    else
+        target.velocity += sf::Vector2f(30.f, 30.f);
+
     particleSystem[ParticlesGame::PARTICLES_WORLD].addEmitter({hitbox.left,hitbox.top+25.f},10,{35,40},{35,40},{35,40});
 }


### PR DESCRIPTION
Rock.cpp: lines 11 to 14 -> Giant´s attack bug fix. Problem ocurred when the player was still and on top of the giant. Both the player´s and the rock´s velocities were 0, so their sum was also 0 and the player did not move.

Game.cpp: line 53 -> float cast so it would compile in Visual Studio.

This is my very first ever contribution to Github, so be careful before merging.
