### PR TITLE
Solves 2 issues: the game over and the ESC key screens

### DIFF
--- a/SubMenu.cpp
+++ b/SubMenu.cpp
@@ -1,0 +1,64 @@
+#include "SubMenu.h"
+
+
+SubMenu::SubMenu(std::string fontPath, std::string texturePath, std::string menu_type) {
+
+	menuType = menu_type;
+
+	if (!font.loadFromFile(fontPath)) {}
+	if (!texture.loadFromFile(texturePath)) {}
+	
+	if (menuType == "game_over") {
+
+		logo.setString("GAME OVER");
+		logo.setCharacterSize(80);
+		logo.setFont(font);
+		logo.setPosition(500 - (logo.getGlobalBounds().width / 2), 50.f);
+		logo.setFillColor(sf::Color::White);
+	}
+
+	if (menuType == "escape_key") {
+
+		bResume = Button("Resume Game", 62, sf::Color::Black, { 250.f, 50.f }, { 500.f,150.f }, sf::Color(92, 64, 51), font);
+		bResume.hoverContentColor = sf::Color::White;
+		bResume.activeContentColor = sf::Color::White;
+
+		bSettings = Button("Settings", 62, sf::Color::Black, { 250.f, 250.f }, { 500.f,150.f }, sf::Color(92, 64, 51), font);
+		bSettings.hoverContentColor = sf::Color::White;
+		bSettings.activeContentColor = sf::Color::White;
+	}
+
+	bMainMenu = Button("Main Menu", 62, sf::Color::Black, { 250, 450.f }, { 500.f,150.f }, sf::Color(92, 64, 51), font);
+	bMainMenu.hoverContentColor = sf::Color::White;
+	bMainMenu.activeContentColor = sf::Color::White;
+	bExitGame = Button("Exit", 62, sf::Color::Black, { 250, 650.f }, { 500.f,150.f }, sf::Color(92, 64, 51), font);
+	bExitGame.hoverContentColor = sf::Color::White;
+	bExitGame.activeContentColor = sf::Color::White;
+}
+
+void SubMenu::update(sf::Vector2f pos) {
+
+	if (menuType == "escape_key") {
+
+		bResume.update(pos);
+		bSettings.update(pos);
+	}
+
+	bExitGame.update(pos);
+	bMainMenu.update(pos);
+}
+
+void SubMenu::draw(sf::RenderTarget& target, sf::RenderStates states) const {
+
+	if (menuType == "escape_key") {
+	
+		target.draw(bSettings);
+		target.draw(bResume);
+	}
+
+	if (menuType == "game_over")
+		target.draw(logo);
+
+	target.draw(bMainMenu);
+	target.draw(bExitGame);
+}

--- a/SubMenu.h
+++ b/SubMenu.h
@@ -1,0 +1,32 @@
+#ifndef SUB_MENU_H
+#define SUB_MENU_H
+
+#include "Game.h"
+#include "Button.h"
+#include <SFML/Graphics.hpp>
+#include "noise/perlinNoise.h"
+
+// This class was created to produce the game over and the ESC key screens. Since in both cases we have the creation of a menu, I use 
+// a single class for both of them. The class is an altered copy of the Menu class, but in an attempt do decrease the amount of 
+// changes to the original code, and due to my lack of familiarity with it, I chose to simply create a new class.
+// The way I separated the ESC key menu from the game over one is not object oriented, so that is one way to improve this code.
+
+class SubMenu : public sf::Drawable {
+
+    public:
+        sf::Text logo;
+        Button bMainMenu;
+        Button bResume;
+        Button bExitGame;
+        Button bSettings;
+
+        SubMenu(std::string fontPath, std::string texturePath, std::string menu_type);
+        void update(sf::Vector2f pos);
+
+    private:
+        std::string menuType;
+        sf::Font font;
+        sf::Texture texture;
+        virtual void draw(sf::RenderTarget& target, sf::RenderStates states) const;
+};
+#endif // SUB_MENU_H


### PR DESCRIPTION
The following change solves 2 issues: the game over screen and the ESC key screen.

This was done by creating a new class SubMenu(.h/.cpp), and making the appropriate changes in main.cpp. In main.cpp, comments along the code will explain where the changes were made.
