### PR TITLE
Pressing ESC after death bug fix + 

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -84,8 +84,8 @@ while(window.isOpen()){
         case 3:
             if (event.type == sf::Event::KeyPressed) {
 
-                // Menu to be presented upon pressing escape
-                if (event.key.code == sf::Keyboard::Escape) {
+                // Sets the flag to present the ESC key menu if the player is not dead.
+                if (event.key.code == sf::Keyboard::Escape && !game.player->isDead()) {
                     
                     if (!game.paused)
                         escapeKeyPressed = true;
@@ -93,7 +93,6 @@ while(window.isOpen()){
                         escapeKeyPressed = false;
 
                     game.paused = !game.paused;
-
                 }
             }
              if(event.type==sf::Event::TextEntered){
@@ -117,8 +116,6 @@ while(window.isOpen()){
             }
         break;
         }
-
-
     }
     switch (mode) {
     case 1:
@@ -136,7 +133,7 @@ while(window.isOpen()){
         window.draw(game);
         
         //  Menu to be presented upon the player's death
-        if (game.player->getHealth() < 0.1f) {    // For some reason health never reaches 0.
+        if (game.player->isDead()) {
 
             game.paused = true;
             mousePos = window.mapPixelToCoords(windowPosition);
@@ -155,8 +152,8 @@ while(window.isOpen()){
                     game.paused = false;
 
                     // Recreating the game object was the only way I found to reset the game.
-                    Game game("texture.png", "font.ttf", &window, &viewUI); 
-                }
+                    Game game("texture.png", "font.ttf", &window, &viewUI);
+                 }
             }
         }
         break;

--- a/playerClasses/Player.cpp
+++ b/playerClasses/Player.cpp
@@ -14,7 +14,10 @@ bodyType=LIVING;
 Player::Player() : Character(){}
 
 void Player::update(sf::Time elapsed, std::vector<std::unique_ptr<Monster>>& monsters){
-regenerate(elapsed);
+
+if(getHealth() > 0.0f) // This stops the player from regenerating after death
+    regenerate(elapsed);
+
 attackDelay-=elapsed;
 ability1Cooldown-=elapsed;
 ability2Cooldown-=elapsed;


### PR DESCRIPTION
Player.cpp -> line 17:  Method update() now checks if the player is alive before regenerating health. This allows method Character::isDead() to function properly with the player object.

main.cpp -> line 87:  Character::isDead() check added to prevent the player from continuing playing after death by simply pressing 
                     ESC.
                -> line 135: Replaced health check for Character::isDead().