### PR TITLE
solves issue #23: changing settings from submenu

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -393,3 +393,11 @@ break;
 }
 player->setLevel(10);
 }
+
+// Updates the current game to new settings
+void Game::updateSettings(Settings& new_settings) {
+
+    // For now, the only setting that may require updating
+    player->movementWSAD(new_settings.WSAD);
+}
+

--- a/Game.h
+++ b/Game.h
@@ -1,6 +1,7 @@
 #ifndef GAME_H
 #define GAME_H
 
+#include "Settings.h"
 #include "Monster.h"
 #include "playerClasses/Player.h"
 #include "playerClasses/Paladin.h"
@@ -41,6 +42,9 @@ void update(sf::Time elapsed, sf::Vector2f globalPos);
 void changeMap(uint32_t seed, int octaves, float bias);
 Game(std::string texturePath, std::string fontPath,const sf::RenderWindow* w, sf::View* v);
 void changePlayerClass(int playerClass);
+
+// Updates the current game to new settings
+void updateSettings(Settings& new_settings);
 
 private:
 

--- a/main.cpp
+++ b/main.cpp
@@ -71,7 +71,7 @@ while(window.isOpen()){
                     wCreator.checkClick(mousePos);
                     if(wCreator.bStartGame.click(mousePos)){
                     game.changePlayerClass(wCreator.playerClass);
-                    game.player->movementWSAD(settings.WSAD);
+                    game.updateSettings(settings);
                     game.changeMap(wCreator.seed,wCreator.octaves, wCreator.bias);
                     mode=3;
                     wCreator.clearVectors();
@@ -104,9 +104,12 @@ while(window.isOpen()){
 
             if(settings.bGoBack.click(mousePos) && !escapeKeyPressed)
                 mode = 1; // If the escape key had not been pressed, we were in the main menu
-            if(settings.bGoBack.click(mousePos) && escapeKeyPressed)
-                mode = 3; // If it had, we were in the escape key menu
 
+            if (settings.bGoBack.click(mousePos) && escapeKeyPressed) {
+
+                mode = 3; // If the escape key had been pressed, we were in the escape key menu
+                game.updateSettings(settings); // Updates the current game with the changes made in the settings
+            }
         break;
         case 5:
             info.update(mousePos);


### PR DESCRIPTION
## Description

At first, since there's currently only one changeable setting (WSAD), I was simply going to update this particular setting in main.cpp. However, as the game grows and more settings are added we would have to keep adding lines to main.cpp. So instead I created a new method in Game.h/cpp to update settings.

Game.h: line 4-> includes Settings.h;
              line 46-> declares Game::updateSettings method;

Game.cpp: line 397-> Implements Game::updateSettings method;

Main.cpp: line 74 -> replaces game.player->movementWSAD with game.updateSettings;
                line 111-> Adds game.updateSettings;

## Stability

Compiled and tested.
